### PR TITLE
Option argument can be passed to render to a specific monitor (xrandr syntax)

### DIFF
--- a/lazywal-cli
+++ b/lazywal-cli
@@ -9,7 +9,7 @@ _help()
 	echo "		-r		- Restore last wallpaper"
 	echo "		-k		- Kill wallpaper"
 	echo "		-d		- Debug"
-	echo "      -D		- Display with specification (e.g., 1980x1080+0)"
+	echo "		-D		- Display with specification (e.g., 1980x1080+0)"
 }
 
 xwinwrap_func()

--- a/lazywal-cli
+++ b/lazywal-cli
@@ -9,6 +9,23 @@ _help()
 	echo "		-r		- Restore last wallpaper"
 	echo "		-k		- Kill wallpaper"
 	echo "		-d		- Debug"
+	echo "      -D		- Display with specification (e.g., 1980x1080+0)"
+}
+
+xwinwrap_func()
+{
+	if [ "$display" = "" ];then
+		# https://superuser.com/questions/196532/how-do-i-find-out-my-screen-resolution-from-a-shell-script
+		display=$(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/')
+		xwinwrap_args="-g $display -ni -b -st -un -o 1.0 -ov -debug"
+	fi
+
+	xwinwrap_args="-g $display -ni -b -st -un -o 1.0 -ov -debug"
+}
+
+_set_display()
+{
+	display=$1
 }
 
 _kill()
@@ -21,7 +38,7 @@ _use_wal()
 {
 	_kill
 	file_path=$1
-	xwinwrap_args="-fs -ni -b -nf -un -o 1.0 -ov -debug"
+	xwinwrap_func
 	mpv_args="-wid WID --loop --no-audio --no-resume-playback --panscan=1.0"
 
 	if [ "$debug" = "true" ];
@@ -45,7 +62,7 @@ then
 	exit 1
 fi
 
-while getopts "hdrk" option; do
+while getopts "hdrkD:" option; do
 	case $option in
 		h) # display Help
 			_help
@@ -60,13 +77,17 @@ while getopts "hdrk" option; do
 		r) # restore wal
 			_restore
 			exit;;
+		D) # display on specification (use this for external monitors)
+			_set_display ${OPTARG}
+			_restore
+			exit;;
 		*) # Illegal option
 			_help
 			exit;;
 	esac
 done
 
-for i in $*; do
+for i in "$@"; do
 	if [ -e $i ]
 	then
 		file_path=$(realpath $i)


### PR DESCRIPTION
### Use option as in the examples:

**Ex1: External monitor in the right of main monitor**
from `xrandr`,
```sh
HDMI-1-0 connected 2560x1080+1920+0 (normal left inverted right x axis y axis) 673mm x 284mm
```

We use,
```sh
lazywal-cli -D 2560x1080+1920 animation.gif
```

**Ex2: Render in the primary display**
From `xrandr`,
```sh
eDP-1 connected primary 1920x1080+0+0
```

We use,
```sh
lazywal-cli -D 1920x1080 animation.gif
```

**DEFAULT: To render in both screens the same gif image (not mirrored)**
```sh
lazywal-cli -D 2560x1080+1920 animation.gif
```